### PR TITLE
Fix CUDA 12.5 build

### DIFF
--- a/submodules/simple-knn/simple_knn.cu
+++ b/submodules/simple-knn/simple_knn.cu
@@ -23,6 +23,9 @@
 #define __CUDACC__
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#ifndef FLT_MAX
+#include <float.h>
+#endif
 
 namespace cg = cooperative_groups;
 


### PR DESCRIPTION
CUDA 12.5 removed the FLT_MAX symbol.
This was previously used without being explicitly imported.
FLT_MAX is defined in <float.h>, including this header fixes the issue

Tested and passed on CUDA 12.6 + Python 3.12.